### PR TITLE
Updated Coinbase exchange URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 RoxygenNote: 7.1.1
 Depends:
-  R(>= 4.0),
+  R(>= 3.6),
   digest,
   jsonlite,
   RCurl,

--- a/R/auth.R
+++ b/R/auth.R
@@ -30,9 +30,9 @@ auth <- function(method,
                  envir = "prod") {
   #define api base url----
   if (envir == "prod") {
-    api.url <- "https://api.pro.coinbase.com"
+    api.url <- "https://api.exchange.coinbase.com"
   } else {
-    api.url <- "https://api-public.sandbox.pro.coinbase.com"
+    api.url <- "https://api-public.sandbox.exchange.coinbase.com"
   }
 
   #generate nonce and key encodings----

--- a/R/parse_response.R
+++ b/R/parse_response.R
@@ -11,7 +11,7 @@
 
 parse_response <- function(path, query = NULL) {
   #define api base url----
-  api.url <- "https://api.pro.coinbase.com"
+  api.url <- "https://api.exchange.coinbase.com"
 
   #create final end point----
   url <- modify_url(api.url, path = path)

--- a/R/public_candles.R
+++ b/R/public_candles.R
@@ -50,7 +50,7 @@ public_candles <- function(product_id = "BTC-USD",
     c("time", "low", "high", "open", "close", "volume")
   content$time <-
     as.POSIXct(content$time, origin = "1970-01-01", tz = "GMT")
-  print(content)
+  #print(content)
 
   #return----
   return(content)


### PR DESCRIPTION
On November 20, 2023, Coinbase moved all remaining end-user funds from Coinbase Pro to Coinbase Advanced Trade:
https://docs.cloud.coinbase.com/advanced-trade-api/docs/migration#:~:text=On%20Nov%2020%202023%2C%20we,from%20Pro%20to%20Coinbase.com

The RGDAX/Pro API works on Coinbase Exchange, a product that targets institutional customers, but Coinbase has changed its URL. We don't know when Coinbase will shut down the old Coinbase Pro API URLs.

This change updates the public and sandbox URLs in the rgdax package, to ensure that it continues to work with Coinbase Exchange in the future.